### PR TITLE
fix for CRAB v3.3.1511

### DIFF
--- a/CMGTools/RootTools/python/samples/samples_13TeV_RunIISpring15MiniAODv2.py
+++ b/CMGTools/RootTools/python/samples/samples_13TeV_RunIISpring15MiniAODv2.py
@@ -140,9 +140,9 @@ GJets_HT600toInf
 
 ### Zinv
 ZJetsToNuNu_HT100to200 = kreator.makeMCComponent("ZJetsToNuNu_HT100to200", "/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "CMS", ".*root",280.47*1.23)
-ZJetsToNuNu_HT200to400 = kreator.makeMCComponent("ZJetsToNuNu_HT200to400", "/ZJetsToNuNu_HT-200to400_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "CMS", ".*root",78.36*1.23) 
-ZJetsToNuNu_HT400to600 = kreator.makeMCComponent("ZJetsToNuNu_HT400to600", "/ZJetsToNuNu_HT-400to600_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "CMS", ".*root",10.94*1.23) 
-ZJetsToNuNu_HT600toInf = kreator.makeMCComponent("ZJetsToNuNu_HT600toInf", "/ZJetsToNuNu_HT-600toInf_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM", "CMS", ".*root",4.203*1.23) 
+ZJetsToNuNu_HT200to400 = kreator.makeMCComponent("ZJetsToNuNu_HT200to400", "/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "CMS", ".*root",78.36*1.23) 
+ZJetsToNuNu_HT400to600 = kreator.makeMCComponent("ZJetsToNuNu_HT400to600", "/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM", "CMS", ".*root",10.94*1.23) 
+ZJetsToNuNu_HT600toInf = kreator.makeMCComponent("ZJetsToNuNu_HT600toInf", "/ZJetsToNuNu_HT-600ToInf_13TeV-madgraph/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v2/MINIAODSIM", "CMS", ".*root",4.203*1.23) 
 ZJetsToNuNuHT = [
 ZJetsToNuNu_HT100to200,
 ZJetsToNuNu_HT200to400,

--- a/CMGTools/TTHAnalysis/cfg/crab_with_das/heppy_crab_config_env.py
+++ b/CMGTools/TTHAnalysis/cfg/crab_with_das/heppy_crab_config_env.py
@@ -26,7 +26,8 @@ if "CMG_TOTAL_UNITS" in os.environ:
   config.Data.totalUnits = int(os.environ["CMG_TOTAL_UNITS"])
 
 config.Data.inputDataset = dataset
-config.Data.publishDataName = m.group(2)+"_"+production_label
+#config.Data.publishDataName = m.group(2)+"_"+production_label
+config.Data.outputDatasetTag = m.group(2)+"_"+production_label
 lumiMask =  os.environ["CMG_LUMI_MASK"]
 if lumiMask != "None":
   config.Data.lumiMask = lumiMask


### PR DESCRIPTION
I got this error when running crab today:
"Invalid CRAB configuration: Parameter Data.publishDataName has been renamed to Data.outputDatasetTag starting from CRAB v3.3.1511; please change your configuration file accordingly."

Made the change, and jobs ran smoothly. Here is a list of other changes in the new crab release::
https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3Releases#CRAB_v3_3_1511_released_on_Novem
